### PR TITLE
Fix incorrect mainGlyphColor rendering on first tablature staff

### DIFF
--- a/frontend/src/pages/Tab.vue
+++ b/frontend/src/pages/Tab.vue
@@ -446,7 +446,7 @@ export default defineComponent({
                         barSeparatorColor: "#6D6D6D",
                         mainGlyphColor: "#A4A4A4",
                         secondaryGlyphColor: "#A4A4A4",
-                        scoreInfoColor: "#A4A4A4",
+                        scoreInfoColor: "#A3A3A3",
                         barNumberColor: "#6D6D6D",
                     };
                 }


### PR DESCRIPTION
With the dark theme, when scoreInfoColor is set to the same value as mainGlyphColor (e.g. #A4A4A4), the text above the first tablature staff (Intro, Chorus I, etc.) is rendered in black, even though it should use mainGlyphColor.
However, changing scoreInfoColor to any slightly different value (e.g. #A3A3A3) prevents the issue.

With same value:
<img width="1053" height="588" alt="Screenshot 2025-11-21 alle 17 47 12" src="https://github.com/user-attachments/assets/352205b5-a793-4620-b240-a2bc3071dbca" />

scoreInfoColor with different value:
<img width="1049" height="580" alt="Screenshot 2025-11-21 alle 17 48 44" src="https://github.com/user-attachments/assets/4c6c7bd9-404f-4180-86d8-1c1d06d1c672" />

