### PR TITLE
Fix iOS audio playback with silent switch enabled

### DIFF
--- a/frontend/src/pages/Tab.vue
+++ b/frontend/src/pages/Tab.vue
@@ -511,7 +511,11 @@ export default defineComponent({
 
                 // iOS 16.4+: Enable audio playback even when silent switch is ON
                 if ("audioSession" in navigator) {
-                    navigator.audioSession.type = "playback";
+                    try {
+                        navigator.audioSession.type = "playback";
+                    } catch (error) {
+                        console.error("Failed to set navigator.audioSession.type to 'playback':", error);
+                    }
                 }
 
                 // Score Loaded


### PR DESCRIPTION
Fixes #24 

Added the official Apple AudioSession API (available since iOS 16.4) to set the audio session type to "playback":

```
  if ("audioSession" in navigator) {
      navigator.audioSession.type = "playback";
  }
```

  This tells iOS to treat Web Audio as media content, allowing playback regardless of the silent switch state.