### PR TITLE
feat: multi-track display, playlists, and file manager improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,56 @@
+# Changelog
+
+## Unreleased
+
+### New Features
+
+#### Multi-track Display
+- Select and display up to 4 tracks simultaneously (e.g. guitar tab + flute score stacked vertically)
+- Toggle individual tracks on/off with a "Show/Shown" button per track row
+- Primary track (for cursor navigation) is set by clicking the track name
+- Track count badge in toolbar shows when multiple tracks are active
+- URL param `?track=` now accepts comma-separated IDs (e.g. `?track=0,2`) for sharing multi-track views
+- Backward compatible: single track ID still works
+
+#### Auto Style Mode (new default)
+- New "Auto" style setting: automatically shows tab notation for stringed instruments (guitar, bass) and standard notation for everything else (flute, violin, piano, etc.)
+- Enables mixed-notation files to render correctly without manual configuration
+- MXL/MusicXML files (notation-only) now render properly in auto mode
+
+#### MusicXML (.mxl) Format Support
+- Added `.mxl` to the list of supported upload formats
+
+#### Playlists
+- Create and manage playlists of tabs
+- Drag-to-reorder tabs within a playlist
+- Add/remove tabs from a playlist
+- Play from playlist context with prev/next navigation buttons in the player
+- Auto-advance: optionally navigate to the next tab automatically when playback ends
+- New `/playlist/:id` page
+
+#### File Manager Improvements
+- Sort tabs by: Date Added (newest/oldest), Title (A–Z), Artist (A–Z)
+- Tag tabs with custom labels; filter tab list by tag
+- Bulk select mode: select multiple tabs, delete or add to playlist in bulk
+- "Select All" / "Deselect All" in bulk mode
+- Playlists section on the home page
+
+#### Track Name Display
+- Track names on staves now show the MIDI instrument name (e.g. "Overdriven Guitar") instead of the raw file metadata name
+- Short abbreviations used in stave margins for readability (e.g. "Gtr", "Bass", "Flute", "Str")
+
+### Settings
+- Added "Auto" style option (now the default)
+- Added "Sort tabs by" preference
+- Added "Auto-advance to next tab in playlist" toggle
+
+## 1.6.2
+
+- fmt
+
+## 1.6.1 — 1.6.0
+
+- fix: regression bug, remember the selected track
+- fix: drum score is not able to render
+- Add ability to load/save settings to server
+- Allow track switching during playback

--- a/backend/common.ts
+++ b/backend/common.ts
@@ -5,6 +5,7 @@ export const supportedFormatList = [
     "gp4",
     "gp5",
     "musicxml",
+    "mxl",
     "capx",
 ];
 
@@ -156,6 +157,36 @@ export const midiProgramCodeList = {
     125: "Helicopter",
     126: "Applause",
     127: "Gunshot",
+};
+
+export function getShortInstrumentName(program: number): string {
+    if (program === 0) return "Drums";
+    if (program >= 1 && program <= 7) return "Keys";
+    if (program >= 8 && program <= 15) return "Perc";
+    if (program >= 16 && program <= 23) return "Organ";
+    if (program >= 24 && program <= 31) return "Gtr";
+    if (program >= 32 && program <= 39) return "Bass";
+    if (program >= 40 && program <= 55) return "Str";
+    if (program >= 56 && program <= 63) return "Brass";
+    if (program >= 64 && program <= 67) return "Sax";
+    if (program >= 68 && program <= 79) return midiShortNames[program] || "Wind";
+    if (program >= 80 && program <= 103) return "Synth";
+    return "Inst";
+}
+
+const midiShortNames: Record<number, string> = {
+    68: "Oboe",
+    69: "E.Horn",
+    70: "Bsn",
+    71: "Clar",
+    72: "Picc",
+    73: "Flute",
+    74: "Rec",
+    75: "Pan Fl",
+    76: "Bottle",
+    77: "Shaku",
+    78: "Whistle",
+    79: "Ocar",
 };
 
 export function isGuitarOrBass(program: number) {

--- a/backend/main.ts
+++ b/backend/main.ts
@@ -2,7 +2,7 @@ import { serve, ServerType } from "@hono/node-server";
 import { Context, Hono } from "@hono/hono";
 import * as fs from "@std/fs";
 import { auth, checkLogin, getCurrentSession, isFinishSetup, isLoggedIn } from "./auth.ts";
-import { SignUpSchema, SyncRequestSchema, UpdateTabFavSchema, UpdateTabInfoSchema, YoutubeAddDataSchema } from "./zod.ts";
+import { CreatePlaylistSchema, SignUpSchema, SyncRequestSchema, UpdatePlaylistSchema, UpdateTabFavSchema, UpdateTabInfoSchema, YoutubeAddDataSchema } from "./zod.ts";
 import { db, hasUser, isInitDB, kv, migrate } from "./db.ts";
 import { cors } from "@hono/hono/cors";
 import { serveStatic } from "@hono/hono/deno";
@@ -35,6 +35,7 @@ import { ZodError } from "zod";
 import sanitize from "sanitize-filename";
 import "@std/dotenv/load";
 import { socketIO } from "./socket.ts";
+import { addTabToPlaylist, createPlaylist, deletePlaylist, getAllPlaylists, getPlaylist, removeTabFromPlaylist, updatePlaylist } from "./playlist.ts";
 import * as cheerio from "cheerio";
 
 let httpServer: ServerType;
@@ -644,6 +645,107 @@ export async function main() {
             const session = await getCurrentSession(c);
             const body = await c.req.json();
             await kv.set(["user_setting", session.user.id], body);
+            return c.json({ ok: true });
+        } catch (e) {
+            return generalError(c, e);
+        }
+    });
+
+    // --- Playlist routes ---
+
+    // List all playlists
+    app.get("/api/playlists", async (c) => {
+        try {
+            await checkLogin(c);
+            const playlists = await getAllPlaylists();
+            return c.json({ ok: true, playlists });
+        } catch (e) {
+            return generalError(c, e);
+        }
+    });
+
+    // Create playlist
+    app.post("/api/playlist", async (c) => {
+        try {
+            await checkLogin(c);
+            const body = CreatePlaylistSchema.parse(await c.req.json());
+            const playlist = await createPlaylist(body);
+            return c.json({ ok: true, playlist });
+        } catch (e) {
+            return generalError(c, e);
+        }
+    });
+
+    // Get playlist
+    app.get("/api/playlist/:id", async (c) => {
+        try {
+            await checkLogin(c);
+            const id = c.req.param("id");
+            const playlist = await getPlaylist(id);
+
+            // Resolve tab info for each tab in the playlist
+            const tabs = [];
+            for (const tabId of playlist.tabIds) {
+                try {
+                    const tab = await getTab(tabId);
+                    tabs.push(tab);
+                } catch {
+                    // Tab may have been deleted — skip it
+                }
+            }
+
+            return c.json({ ok: true, playlist, tabs });
+        } catch (e) {
+            return generalError(c, e);
+        }
+    });
+
+    // Update playlist (name and/or tab order)
+    app.put("/api/playlist/:id", async (c) => {
+        try {
+            await checkLogin(c);
+            const id = c.req.param("id");
+            const body = UpdatePlaylistSchema.parse(await c.req.json());
+            const playlist = await updatePlaylist(id, body);
+            return c.json({ ok: true, playlist });
+        } catch (e) {
+            return generalError(c, e);
+        }
+    });
+
+    // Delete playlist
+    app.delete("/api/playlist/:id", async (c) => {
+        try {
+            await checkLogin(c);
+            const id = c.req.param("id");
+            await deletePlaylist(id);
+            return c.json({ ok: true });
+        } catch (e) {
+            return generalError(c, e);
+        }
+    });
+
+    // Add tab to playlist
+    app.post("/api/playlist/:id/tab/:tabId", async (c) => {
+        try {
+            await checkLogin(c);
+            const id = c.req.param("id");
+            const tabId = c.req.param("tabId");
+            await checkTabExists(tabId);
+            await addTabToPlaylist(id, tabId);
+            return c.json({ ok: true });
+        } catch (e) {
+            return generalError(c, e);
+        }
+    });
+
+    // Remove tab from playlist
+    app.delete("/api/playlist/:id/tab/:tabId", async (c) => {
+        try {
+            await checkLogin(c);
+            const id = c.req.param("id");
+            const tabId = c.req.param("tabId");
+            await removeTabFromPlaylist(id, tabId);
             return c.json({ ok: true });
         } catch (e) {
             return generalError(c, e);

--- a/backend/playlist.ts
+++ b/backend/playlist.ts
@@ -1,0 +1,111 @@
+import { kv } from "./db.ts";
+import { CreatePlaylist, CreatePlaylistSchema, Playlist, PlaylistSchema, UpdatePlaylist } from "./zod.ts";
+
+/**
+ * Get the next playlist ID using atomic counter in Deno KV.
+ */
+async function getNextPlaylistID(): Promise<string> {
+    while (true) {
+        const key = ["counter", "playlist_id"];
+        const res = await kv.get<Deno.KvU64>(key);
+        const current = res.value || new Deno.KvU64(0n);
+        const next = new Deno.KvU64(current.value + 1n);
+        const commit = await kv.atomic()
+            .check({ key, versionstamp: res.versionstamp })
+            .mutate({ type: "set", key, value: next })
+            .commit();
+        if (commit.ok) {
+            return String(next.value);
+        }
+    }
+}
+
+/**
+ * Create a new playlist.
+ */
+export async function createPlaylist(data: CreatePlaylist): Promise<Playlist> {
+    const id = await getNextPlaylistID();
+    const playlist = PlaylistSchema.parse({
+        id,
+        name: data.name,
+        tabIds: [],
+        createdAt: new Date().toISOString(),
+    });
+    await kv.set(["playlist", id], playlist);
+    return playlist;
+}
+
+/**
+ * Get a single playlist by ID.
+ */
+export async function getPlaylist(id: string): Promise<Playlist> {
+    const entry = await kv.get(["playlist", id]);
+    if (!entry.value) {
+        throw new Error("Playlist not found");
+    }
+    return PlaylistSchema.parse(entry.value);
+}
+
+/**
+ * Get all playlists.
+ */
+export async function getAllPlaylists(): Promise<Playlist[]> {
+    const playlists: Playlist[] = [];
+    const iter = kv.list({ prefix: ["playlist"] });
+    for await (const entry of iter) {
+        try {
+            playlists.push(PlaylistSchema.parse(entry.value));
+        } catch {
+            // Skip invalid entries
+        }
+    }
+    // Sort by createdAt (newest first)
+    playlists.sort((a, b) => new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime());
+    return playlists;
+}
+
+/**
+ * Update a playlist (name and/or tab order).
+ */
+export async function updatePlaylist(id: string, data: UpdatePlaylist): Promise<Playlist> {
+    const playlist = await getPlaylist(id);
+    if (data.name !== undefined) {
+        playlist.name = data.name;
+    }
+    if (data.tabIds !== undefined) {
+        playlist.tabIds = data.tabIds;
+    }
+    await kv.set(["playlist", id], playlist);
+    return playlist;
+}
+
+/**
+ * Delete a playlist.
+ */
+export async function deletePlaylist(id: string): Promise<void> {
+    const entry = await kv.get(["playlist", id]);
+    if (!entry.value) {
+        throw new Error("Playlist not found");
+    }
+    await kv.delete(["playlist", id]);
+}
+
+/**
+ * Add a tab to a playlist. Does nothing if already present.
+ */
+export async function addTabToPlaylist(playlistId: string, tabId: string): Promise<void> {
+    const playlist = await getPlaylist(playlistId);
+    if (!playlist.tabIds.includes(tabId)) {
+        playlist.tabIds.push(tabId);
+        await kv.set(["playlist", playlistId], playlist);
+    }
+}
+
+/**
+ * Remove a tab from a playlist.
+ */
+export async function removeTabFromPlaylist(playlistId: string, tabId: string): Promise<void> {
+    const playlist = await getPlaylist(playlistId);
+    playlist.tabIds = playlist.tabIds.filter((id) => id !== tabId);
+    await kv.set(["playlist", playlistId], playlist);
+}

--- a/backend/tab.ts
+++ b/backend/tab.ts
@@ -313,6 +313,7 @@ export async function updateTab(tab: TabInfo, data: UpdateTabInfo) {
     tab.title = data.title;
     tab.artist = data.artist;
     tab.public = data.public;
+    tab.tags = data.tags;
     await writeTabInfo(tab);
 }
 

--- a/backend/tab_test.ts
+++ b/backend/tab_test.ts
@@ -246,6 +246,7 @@ Deno.test("updateTab", async () => {
         title: "Updated Title",
         artist: "Updated Artist",
         public: true,
+        tags: ["rock", "practice"],
     });
 
     // Check updated

--- a/backend/zod.ts
+++ b/backend/zod.ts
@@ -21,6 +21,7 @@ export const TabInfoSchema = z.object({
     createdAt: z.iso.datetime().default(() => new Date().toISOString()),
     public: isPublic.default(false),
     fav: isFav.default(false),
+    tags: z.array(z.string()).default([]),
 });
 export type TabInfo = z.infer<typeof TabInfoSchema>;
 
@@ -28,6 +29,7 @@ export const UpdateTabInfoSchema = z.object({
     title,
     artist,
     public: isPublic,
+    tags: z.array(z.string()).default([]),
 });
 export type UpdateTabInfo = z.infer<typeof UpdateTabInfoSchema>;
 
@@ -76,3 +78,23 @@ export const ConfigJSONSchema = z.object({
     youtube: z.array(YoutubeSchema).default([]),
 });
 export type ConfigJSON = z.infer<typeof ConfigJSONSchema>;
+
+// Playlist schemas
+export const PlaylistSchema = z.object({
+    id: z.string(),
+    name: z.string().min(1),
+    tabIds: z.array(z.string()).default([]),
+    createdAt: z.iso.datetime().default(() => new Date().toISOString()),
+});
+export type Playlist = z.infer<typeof PlaylistSchema>;
+
+export const CreatePlaylistSchema = z.object({
+    name: z.string().min(1),
+});
+export type CreatePlaylist = z.infer<typeof CreatePlaylistSchema>;
+
+export const UpdatePlaylistSchema = z.object({
+    name: z.string().min(1).optional(),
+    tabIds: z.array(z.string()).optional(),
+});
+export type UpdatePlaylist = z.infer<typeof UpdatePlaylistSchema>;

--- a/frontend/src/app.ts
+++ b/frontend/src/app.ts
@@ -1,5 +1,5 @@
 import { io } from "socket.io-client";
-import { midiProgramCodeList } from "../../backend/common.ts";
+import { getShortInstrumentName, isGuitarOrBass, midiProgramCodeList } from "../../backend/common.ts";
 import { notify } from "@kyvg/vue3-notification";
 import { SettingSchema } from "./zod.ts";
 
@@ -33,6 +33,8 @@ export const baseURL = getBaseURL();
 export function getInstrumentName(midiProgram: number) {
     return midiProgramCodeList[midiProgram] || "Unknown";
 }
+
+export { getShortInstrumentName, isGuitarOrBass };
 
 export async function checkFetch(res: Response): Promise<void> {
     let data;

--- a/frontend/src/components/TabItem.vue
+++ b/frontend/src/components/TabItem.vue
@@ -13,9 +13,17 @@ export default defineComponent({
             type: Boolean,
             default: true,
         },
+        selectable: {
+            type: Boolean,
+            default: false,
+        },
+        selected: {
+            type: Boolean,
+            default: false,
+        },
     },
 
-    emits: ["delete", "favToggled"],
+    emits: ["delete", "favToggled", "toggleSelected"],
 
     methods: {
         handleEdit() {
@@ -60,8 +68,17 @@ export default defineComponent({
 </script>
 
 <template>
-    <div class="tab-item p-3 rounded">
+    <div class="tab-item p-3 rounded" :class='{ "selected": selected }'>
+        <input
+            v-if="selectable"
+            type="checkbox"
+            class="form-check-input select-checkbox"
+            :checked="selected"
+            @change='$emit("toggleSelected")'
+        />
+
         <button
+            v-if="!selectable"
             class="fav-btn"
             @click="toggleFav"
             :class='{ "fav-active": tab.fav }'
@@ -74,6 +91,9 @@ export default defineComponent({
         <router-link class="info" :to="`/tab/${tab.id}`">
             <div class="title">{{ tab.title }}</div>
             <div class="artist" v-if="showArtist">{{ tab.artist }}</div>
+            <div class="tags" v-if="tab.tags && tab.tags.length > 0">
+                <span v-for="tag in tab.tags" :key="tag" class="badge bg-secondary me-1">{{ tag }}</span>
+            </div>
         </router-link>
 
         <button class="btn btn-secondary me-2" @click="handleEdit">
@@ -93,8 +113,28 @@ export default defineComponent({
     display: flex;
     transition: background-color 0.1s;
 
+    &.selected {
+        background-color: rgba(13, 110, 253, 0.1);
+    }
+
     &:hover {
         background-color: rgba(0, 0, 0, 0.05);
+    }
+
+    .select-checkbox {
+        align-self: center;
+        margin-right: 12px;
+        width: 22px;
+        height: 22px;
+        min-width: 22px;
+        cursor: pointer;
+    }
+
+    .tags {
+        margin-top: 4px;
+        .badge {
+            font-size: 11px;
+        }
     }
 
     .fav-btn {

--- a/frontend/src/pages/Home.vue
+++ b/frontend/src/pages/Home.vue
@@ -13,10 +13,14 @@ export default defineComponent({
     data() {
         return {
             tabList: [],
+            playlists: [],
             ready: false,
             isLoggedIn: false,
             searchQuery: "",
             setting: {},
+            selectedTagFilter: "",
+            selectMode: false,
+            selectedTabIds: [],
         };
     },
 
@@ -30,9 +34,16 @@ export default defineComponent({
         }
 
         try {
-            const res = await fetch(baseURL + "/api/tabs", { credentials: "include" });
-            const data = await res.json();
-            this.tabList = data.tabs;
+            const [tabRes, playlistRes] = await Promise.all([
+                fetch(baseURL + "/api/tabs", { credentials: "include" }),
+                fetch(baseURL + "/api/playlists", { credentials: "include" }),
+            ]);
+            const tabData = await tabRes.json();
+            this.tabList = tabData.tabs;
+
+            const playlistData = await playlistRes.json();
+            this.playlists = playlistData.playlists || [];
+
             this.ready = true;
 
             await this.$nextTick();
@@ -46,16 +57,58 @@ export default defineComponent({
     },
 
     computed: {
+        sortedTabList() {
+            const tabs = [...this.tabList];
+            const sortBy = this.setting.tabSortBy || "dateNewest";
+
+            switch (sortBy) {
+                case "title":
+                    tabs.sort((a, b) => (a.title || "").localeCompare(b.title || ""));
+                    break;
+                case "artist":
+                    tabs.sort((a, b) => (a.artist || "").localeCompare(b.artist || ""));
+                    break;
+                case "dateOldest":
+                    tabs.sort((a, b) => new Date(a.createdAt).getTime() - new Date(b.createdAt).getTime());
+                    break;
+                case "dateNewest":
+                default:
+                    tabs.sort((a, b) => new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime());
+                    break;
+            }
+
+            return tabs;
+        },
+
         filteredTabList() {
-            if (!this.searchQuery.trim()) return this.tabList;
+            let tabs = this.sortedTabList;
 
-            const query = this.searchQuery.trim().toLowerCase();
+            // Filter by search query
+            if (this.searchQuery.trim()) {
+                const query = this.searchQuery.trim().toLowerCase();
+                tabs = tabs.filter((tab) => {
+                    const title = (tab.title || "").toLowerCase();
+                    const artist = (tab.artist || "").toLowerCase();
+                    return title.includes(query) || artist.includes(query);
+                });
+            }
 
-            return this.tabList.filter((tab) => {
-                const title = (tab.title || "").toLowerCase();
-                const artist = (tab.artist || "").toLowerCase();
-                return title.includes(query) || artist.includes(query);
-            });
+            // Filter by tag
+            if (this.selectedTagFilter) {
+                tabs = tabs.filter((tab) => (tab.tags || []).includes(this.selectedTagFilter));
+            }
+
+            return tabs;
+        },
+
+        allTags() {
+            const tagSet = new Set();
+            for (const tab of this.tabList) {
+                for (const tag of (tab.tags || [])) {
+                    tagSet.add(tag);
+                }
+            }
+            return [...tagSet].sort();
         },
 
         favoritedTabs() {
@@ -99,6 +152,139 @@ export default defineComponent({
             this.tabList = [...this.tabList];
         },
 
+        toggleSelectMode() {
+            this.selectMode = !this.selectMode;
+            if (!this.selectMode) {
+                this.selectedTabIds = [];
+            }
+        },
+
+        toggleTabSelection(id) {
+            const idx = this.selectedTabIds.indexOf(id);
+            if (idx >= 0) {
+                this.selectedTabIds.splice(idx, 1);
+            } else {
+                this.selectedTabIds.push(id);
+            }
+        },
+
+        selectAll() {
+            this.selectedTabIds = this.filteredTabList.map((tab) => tab.id);
+        },
+
+        deselectAll() {
+            this.selectedTabIds = [];
+        },
+
+        async bulkDelete() {
+            if (this.selectedTabIds.length === 0) return;
+            if (!confirm(`Are you sure you want to delete ${this.selectedTabIds.length} tab(s)?`)) return;
+
+            let deleted = 0;
+            for (const id of this.selectedTabIds) {
+                try {
+                    const res = await fetch(baseURL + `/api/tab/${id}`, {
+                        method: "DELETE",
+                        credentials: "include",
+                    });
+                    if (res.status === 200) {
+                        deleted++;
+                    }
+                } catch (error) {
+                    console.error(`Failed to delete tab ${id}:`, error);
+                }
+            }
+
+            this.tabList = this.tabList.filter((tab) => !this.selectedTabIds.includes(tab.id));
+            this.selectedTabIds = [];
+
+            notify({
+                text: `Deleted ${deleted} tab(s)`,
+                type: "success",
+            });
+        },
+
+        filterByTag(tag) {
+            if (this.selectedTagFilter === tag) {
+                this.selectedTagFilter = "";
+            } else {
+                this.selectedTagFilter = tag;
+            }
+        },
+
+        async createPlaylist() {
+            const name = prompt("Playlist name:");
+            if (!name || !name.trim()) return;
+
+            try {
+                const res = await fetch(baseURL + "/api/playlist", {
+                    method: "POST",
+                    credentials: "include",
+                    headers: { "Content-Type": "application/json" },
+                    body: JSON.stringify({ name: name.trim() }),
+                });
+                const data = await res.json();
+                if (data.playlist) {
+                    this.playlists.unshift(data.playlist);
+                    notify({ text: "Playlist created", type: "success" });
+                }
+            } catch (error) {
+                notify({ text: error.message, type: "error" });
+            }
+        },
+
+        async deletePlaylist(id, name) {
+            if (!confirm(`Delete playlist "${name}"?`)) return;
+
+            try {
+                const res = await fetch(baseURL + `/api/playlist/${id}`, {
+                    method: "DELETE",
+                    credentials: "include",
+                });
+                if (res.ok) {
+                    this.playlists = this.playlists.filter((p) => p.id !== id);
+                    notify({ text: "Playlist deleted", type: "success" });
+                }
+            } catch (error) {
+                notify({ text: error.message, type: "error" });
+            }
+        },
+
+        async bulkAddToPlaylist() {
+            if (this.selectedTabIds.length === 0) return;
+            if (this.playlists.length === 0) {
+                notify({ text: "Create a playlist first", type: "error" });
+                return;
+            }
+
+            const names = this.playlists.map((p) => p.name);
+            const choice = prompt(`Add ${this.selectedTabIds.length} tab(s) to which playlist?\n\n${names.map((n, i) => `${i + 1}. ${n}`).join("\n")}\n\nEnter number:`);
+            if (!choice) return;
+
+            const idx = parseInt(choice) - 1;
+            if (isNaN(idx) || idx < 0 || idx >= this.playlists.length) {
+                notify({ text: "Invalid selection", type: "error" });
+                return;
+            }
+
+            const playlist = this.playlists[idx];
+            let added = 0;
+            for (const tabId of this.selectedTabIds) {
+                try {
+                    await fetch(baseURL + `/api/playlist/${playlist.id}/tab/${tabId}`, {
+                        method: "POST",
+                        credentials: "include",
+                    });
+                    added++;
+                } catch {
+                    // skip
+                }
+            }
+
+            notify({ text: `Added ${added} tab(s) to "${playlist.name}"`, type: "success" });
+            this.selectedTabIds = [];
+        },
+
         async deleteTab(id, title, artist) {
             if (!confirm(`Are you sure you want to delete ${artist} - ${title}?`)) return;
 
@@ -132,6 +318,29 @@ export default defineComponent({
 
 <template>
     <div class="container my-container">
+        <!-- Playlists Section -->
+        <div class="playlists-section ms-3 me-3 mt-3 mb-3" v-if="ready && (playlists.length > 0 || isLoggedIn)">
+            <div class="d-flex align-items-center justify-content-between mb-2">
+                <h5 class="mb-0">Playlists</h5>
+                <button class="btn btn-sm btn-outline-primary" @click="createPlaylist">
+                    <font-awesome-icon :icon='["fas", "plus"]' />
+                    New Playlist
+                </button>
+            </div>
+            <div class="playlist-cards d-flex flex-wrap gap-2">
+                <div v-for="pl in playlists" :key="pl.id" class="playlist-card p-2 rounded d-flex align-items-center gap-2">
+                    <router-link :to="`/playlist/${pl.id}`" class="flex-grow-1">
+                        <strong>{{ pl.name }}</strong>
+                        <small class="text-muted ms-1">({{ pl.tabIds.length }})</small>
+                    </router-link>
+                    <button class="btn btn-sm btn-outline-danger" @click.prevent="deletePlaylist(pl.id, pl.name)">
+                        <font-awesome-icon :icon='["fas", "xmark"]' />
+                    </button>
+                </div>
+            </div>
+            <div v-if="playlists.length === 0" class="text-muted">No playlists yet</div>
+        </div>
+
         <!-- Favorites Section -->
         <div class="favorites-section" v-if="ready && favoritedTabs.length > 0">
             <TabItem
@@ -169,11 +378,49 @@ export default defineComponent({
                     ✕
                 </button>
             </div>
+
+            <div class="d-flex align-items-center gap-2 mt-2">
+                <select class="form-select form-select-sm" style="max-width: 180px" v-model="setting.tabSortBy">
+                    <option value="dateNewest">Newest First</option>
+                    <option value="dateOldest">Oldest First</option>
+                    <option value="title">Title (A-Z)</option>
+                    <option value="artist">Artist (A-Z)</option>
+                </select>
+
+                <button class="btn btn-sm" :class='selectMode ? "btn-primary" : "btn-outline-secondary"' @click="toggleSelectMode">
+                    <font-awesome-icon :icon='["fas", "check-double"]' />
+                    Select
+                </button>
+            </div>
+        </div>
+
+        <!-- Tag filter bar -->
+        <div class="tag-filter-bar ms-3 me-3 mb-3" v-if="ready && allTags.length > 0">
+            <span
+                v-for="tag in allTags"
+                :key="tag"
+                class="badge me-1 tag-chip"
+                :class='selectedTagFilter === tag ? "bg-primary" : "bg-secondary"'
+                @click="filterByTag(tag)"
+                role="button"
+            >{{ tag }}</span>
+        </div>
+
+        <!-- Bulk action bar -->
+        <div class="bulk-actions ms-3 me-3 mb-3 d-flex align-items-center gap-2" v-if="selectMode">
+            <button class="btn btn-sm btn-outline-secondary" @click="selectAll">Select All</button>
+            <button class="btn btn-sm btn-outline-secondary" @click="deselectAll">Deselect All</button>
+            <button class="btn btn-sm btn-outline-primary" @click="bulkAddToPlaylist" :disabled="selectedTabIds.length === 0">
+                Add to Playlist
+            </button>
+            <button class="btn btn-sm btn-danger" @click="bulkDelete" :disabled="selectedTabIds.length === 0">
+                Delete Selected ({{ selectedTabIds.length }})
+            </button>
         </div>
 
         <div class="mb-4 ms-3" v-if="ready">
             Total Tabs: {{ filteredTabList.length }}
-            <span v-if="searchQuery" class="text-muted">
+            <span v-if="searchQuery || selectedTagFilter" class="text-muted">
                 (of {{ tabList.length }})
             </span>
         </div>
@@ -187,8 +434,11 @@ export default defineComponent({
                     :key="tab.id"
                     :tab="tab"
                     :show-artist="false"
+                    :selectable="selectMode"
+                    :selected="selectedTabIds.includes(tab.id)"
                     @delete="deleteTab"
                     @favToggled="handleFavToggled"
+                    @toggle-selected="toggleTabSelection(tab.id)"
                 />
             </div>
         </template>
@@ -199,8 +449,11 @@ export default defineComponent({
                 :key="tab.id"
                 :tab="tab"
                 :show-artist="true"
+                :selectable="selectMode"
+                :selected="selectedTabIds.includes(tab.id)"
                 @delete="deleteTab"
                 @favToggled="handleFavToggled"
+                @toggle-selected="toggleTabSelection(tab.id)"
             />
         </template>
 
@@ -229,5 +482,23 @@ export default defineComponent({
 
 h4 {
     color: $color2-dark;
+}
+
+.playlist-card {
+    background-color: #2a2e33;
+    border: 1px solid #444;
+    min-width: 150px;
+
+    a {
+        text-decoration: none;
+    }
+}
+
+.tag-chip {
+    cursor: pointer;
+    font-size: 13px;
+    padding: 5px 10px;
+    user-select: none;
+    transition: background-color 0.2s;
 }
 </style>

--- a/frontend/src/pages/Playlist.vue
+++ b/frontend/src/pages/Playlist.vue
@@ -1,0 +1,360 @@
+<script>
+import { defineComponent } from "vue";
+import { notify } from "@kyvg/vue3-notification";
+import { baseURL, checkFetch, generalError } from "../app.js";
+
+export default defineComponent({
+    data() {
+        return {
+            playlistId: "",
+            playlist: null,
+            tabs: [],
+            ready: false,
+            editingName: false,
+            editName: "",
+            showAddTabs: false,
+            allTabs: [],
+            addSearchQuery: "",
+            dragIndex: null,
+        };
+    },
+
+    async mounted() {
+        this.playlistId = this.$route.params.id;
+        await this.load();
+    },
+
+    computed: {
+        filteredAddTabs() {
+            const existingIds = new Set(this.playlist?.tabIds || []);
+            let available = this.allTabs.filter((tab) => !existingIds.has(tab.id));
+
+            if (this.addSearchQuery.trim()) {
+                const query = this.addSearchQuery.trim().toLowerCase();
+                available = available.filter((tab) => {
+                    return (tab.title || "").toLowerCase().includes(query) ||
+                        (tab.artist || "").toLowerCase().includes(query);
+                });
+            }
+
+            return available;
+        },
+    },
+
+    methods: {
+        async load() {
+            try {
+                const res = await fetch(baseURL + `/api/playlist/${this.playlistId}`, {
+                    credentials: "include",
+                });
+                await checkFetch(res);
+                const data = await res.json();
+                this.playlist = data.playlist;
+                this.tabs = data.tabs;
+                this.ready = true;
+            } catch (e) {
+                generalError(e);
+            }
+        },
+
+        startEditName() {
+            this.editName = this.playlist.name;
+            this.editingName = true;
+            this.$nextTick(() => {
+                this.$refs.nameInput?.focus();
+            });
+        },
+
+        async saveName() {
+            try {
+                const res = await fetch(baseURL + `/api/playlist/${this.playlistId}`, {
+                    method: "PUT",
+                    credentials: "include",
+                    headers: { "Content-Type": "application/json" },
+                    body: JSON.stringify({ name: this.editName }),
+                });
+                await checkFetch(res);
+                this.playlist.name = this.editName;
+                this.editingName = false;
+            } catch (e) {
+                generalError(e);
+            }
+        },
+
+        cancelEditName() {
+            this.editingName = false;
+        },
+
+        async removeTab(tabId) {
+            try {
+                const res = await fetch(baseURL + `/api/playlist/${this.playlistId}/tab/${tabId}`, {
+                    method: "DELETE",
+                    credentials: "include",
+                });
+                await checkFetch(res);
+                this.playlist.tabIds = this.playlist.tabIds.filter((id) => id !== tabId);
+                this.tabs = this.tabs.filter((tab) => tab.id !== tabId);
+            } catch (e) {
+                generalError(e);
+            }
+        },
+
+        async openAddTabs() {
+            this.showAddTabs = true;
+            this.addSearchQuery = "";
+
+            // Fetch all tabs if not loaded
+            if (this.allTabs.length === 0) {
+                try {
+                    const res = await fetch(baseURL + "/api/tabs", { credentials: "include" });
+                    await checkFetch(res);
+                    const data = await res.json();
+                    this.allTabs = data.tabs;
+                } catch (e) {
+                    generalError(e);
+                }
+            }
+        },
+
+        async addTab(tab) {
+            try {
+                const res = await fetch(baseURL + `/api/playlist/${this.playlistId}/tab/${tab.id}`, {
+                    method: "POST",
+                    credentials: "include",
+                });
+                await checkFetch(res);
+                this.playlist.tabIds.push(tab.id);
+                this.tabs.push(tab);
+                notify({ text: `Added "${tab.title}"`, type: "success" });
+            } catch (e) {
+                generalError(e);
+            }
+        },
+
+        // Drag-to-reorder
+        onDragStart(index, event) {
+            this.dragIndex = index;
+            event.dataTransfer.effectAllowed = "move";
+        },
+
+        onDragOver(index, event) {
+            event.preventDefault();
+            event.dataTransfer.dropEffect = "move";
+        },
+
+        async onDrop(targetIndex) {
+            if (this.dragIndex === null || this.dragIndex === targetIndex) {
+                this.dragIndex = null;
+                return;
+            }
+
+            // Reorder tabs array
+            const movedTab = this.tabs.splice(this.dragIndex, 1)[0];
+            this.tabs.splice(targetIndex, 0, movedTab);
+
+            // Reorder tabIds
+            const movedId = this.playlist.tabIds.splice(this.dragIndex, 1)[0];
+            this.playlist.tabIds.splice(targetIndex, 0, movedId);
+
+            this.dragIndex = null;
+
+            // Save new order
+            try {
+                const res = await fetch(baseURL + `/api/playlist/${this.playlistId}`, {
+                    method: "PUT",
+                    credentials: "include",
+                    headers: { "Content-Type": "application/json" },
+                    body: JSON.stringify({ tabIds: this.playlist.tabIds }),
+                });
+                await checkFetch(res);
+            } catch (e) {
+                generalError(e);
+            }
+        },
+
+        onDragEnd() {
+            this.dragIndex = null;
+        },
+
+        playFromPlaylist(tabId) {
+            this.$router.push(`/tab/${tabId}?playlist=${this.playlistId}`);
+        },
+    },
+});
+</script>
+
+<template>
+    <div class="container my-container" v-if="ready">
+        <div class="mt-4 mb-3">
+            <router-link to="/" class="btn btn-outline-secondary btn-sm">
+                <font-awesome-icon :icon='["fas", "arrow-left"]' />
+                Back
+            </router-link>
+        </div>
+
+        <!-- Playlist name -->
+        <div class="mb-4">
+            <div v-if="!editingName" class="d-flex align-items-center gap-2">
+                <h2 class="mb-0">{{ playlist.name }}</h2>
+                <button class="btn btn-sm btn-outline-secondary" @click="startEditName">Rename</button>
+            </div>
+            <div v-else class="d-flex align-items-center gap-2">
+                <input
+                    ref="nameInput"
+                    type="text"
+                    class="form-control"
+                    v-model="editName"
+                    @keyup.enter="saveName"
+                    @keyup.escape="cancelEditName"
+                    style="max-width: 400px"
+                />
+                <button class="btn btn-sm btn-primary" @click="saveName">Save</button>
+                <button class="btn btn-sm btn-outline-secondary" @click="cancelEditName">Cancel</button>
+            </div>
+        </div>
+
+        <div class="mb-3 text-muted">{{ tabs.length }} tab(s)</div>
+
+        <!-- Tabs list (drag-to-reorder) -->
+        <div class="playlist-tabs">
+            <div
+                v-for="(tab, index) in tabs"
+                :key="tab.id"
+                class="playlist-tab-item p-3 rounded d-flex align-items-center"
+                :class='{ "drag-over": dragIndex !== null && dragIndex !== index }'
+                draggable="true"
+                @dragstart="onDragStart(index, $event)"
+                @dragover="onDragOver(index, $event)"
+                @drop="onDrop(index)"
+                @dragend="onDragEnd"
+            >
+                <div class="drag-handle me-3">
+                    <font-awesome-icon :icon='["fas", "grip-vertical"]' />
+                </div>
+
+                <div class="tab-number me-3">{{ index + 1 }}</div>
+
+                <div class="info flex-grow-1" @click="playFromPlaylist(tab.id)" role="button">
+                    <div class="title">{{ tab.title }}</div>
+                    <div class="artist text-muted">{{ tab.artist }}</div>
+                </div>
+
+                <button class="btn btn-sm btn-primary me-2" @click="playFromPlaylist(tab.id)">
+                    <font-awesome-icon :icon='["fas", "play"]' />
+                </button>
+
+                <button class="btn btn-sm btn-outline-danger" @click="removeTab(tab.id)">
+                    Remove
+                </button>
+            </div>
+        </div>
+
+        <!-- Empty state -->
+        <div v-if="tabs.length === 0" class="text-center py-5 text-muted">
+            <p>This playlist is empty. Add some tabs to get started.</p>
+        </div>
+
+        <!-- Add tabs -->
+        <div class="mt-4 mb-5">
+            <button class="btn btn-outline-primary" @click="openAddTabs" v-if="!showAddTabs">
+                <font-awesome-icon :icon='["fas", "plus"]' />
+                Add Tabs
+            </button>
+
+            <div v-if="showAddTabs" class="add-tabs-panel p-3 rounded">
+                <div class="d-flex align-items-center justify-content-between mb-3">
+                    <strong>Add tabs to playlist</strong>
+                    <button class="btn btn-sm btn-outline-secondary" @click="showAddTabs = false">Close</button>
+                </div>
+
+                <input
+                    type="text"
+                    class="form-control mb-3"
+                    v-model="addSearchQuery"
+                    placeholder="Search tabs..."
+                />
+
+                <div class="add-tabs-list">
+                    <div
+                        v-for="tab in filteredAddTabs"
+                        :key="tab.id"
+                        class="add-tab-item d-flex align-items-center p-2 rounded"
+                    >
+                        <div class="flex-grow-1">
+                            <div>{{ tab.title }}</div>
+                            <small class="text-muted">{{ tab.artist }}</small>
+                        </div>
+                        <button class="btn btn-sm btn-outline-primary" @click="addTab(tab)">
+                            Add
+                        </button>
+                    </div>
+
+                    <div v-if="filteredAddTabs.length === 0" class="text-muted text-center p-3">
+                        No tabs available to add
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+</template>
+
+<style scoped lang="scss">
+@import "../styles/vars.scss";
+
+.playlist-tab-item {
+    border-bottom: 1px solid #333;
+    transition: background-color 0.15s;
+    cursor: default;
+
+    &:hover {
+        background-color: rgba(255, 255, 255, 0.03);
+    }
+
+    .drag-handle {
+        cursor: grab;
+        color: #666;
+        font-size: 18px;
+        padding: 8px;
+        touch-action: none;
+
+        &:active {
+            cursor: grabbing;
+        }
+    }
+
+    .tab-number {
+        color: #888;
+        font-size: 14px;
+        min-width: 24px;
+        text-align: center;
+    }
+
+    .info {
+        .title {
+            font-size: 16px;
+        }
+        .artist {
+            font-size: 13px;
+        }
+    }
+}
+
+.add-tabs-panel {
+    border: 1px solid #444;
+    background-color: #2a2e33;
+    max-height: 400px;
+    overflow-y: auto;
+}
+
+.add-tab-item {
+    border-bottom: 1px solid #333;
+
+    &:hover {
+        background-color: rgba(255, 255, 255, 0.05);
+    }
+
+    &:last-child {
+        border-bottom: none;
+    }
+}
+</style>

--- a/frontend/src/pages/Settings.vue
+++ b/frontend/src/pages/Settings.vue
@@ -128,6 +128,7 @@ export default defineComponent({
         <div class="mb-3">
             <label for="scoreStyle" class="form-label">Style</label>
             <select id="scoreStyle" class="form-select" v-model="setting.scoreStyle">
+                <option value="auto">Auto (tab if available, score otherwise)</option>
                 <option value="tab">Tab</option>
                 <option value="score">Score</option>
                 <option value="score-tab">Tab + Score</option>
@@ -218,10 +219,32 @@ export default defineComponent({
 
         <h2 class="mt-5 mb-4">Tab List</h2>
 
+        <!-- Sort by -->
+        <div class="mb-3">
+            <label for="tabSortBy" class="form-label">Sort tabs by</label>
+            <select id="tabSortBy" class="form-select" v-model="setting.tabSortBy">
+                <option value="dateNewest">Date Added (Newest)</option>
+                <option value="dateOldest">Date Added (Oldest)</option>
+                <option value="title">Title (A-Z)</option>
+                <option value="artist">Artist (A-Z)</option>
+            </select>
+        </div>
+
         <!-- Group by artist -->
         <div class="mb-3">
             <label for="groupByArtist" class="form-label">Group tabs by Artist</label>
             <select id="groupByArtist" class="form-select" v-model="setting.groupByArtist">
+                <option :value="false">No</option>
+                <option :value="true">Yes</option>
+            </select>
+        </div>
+
+        <h2 class="mt-5 mb-4">Playlist</h2>
+
+        <!-- Playlist auto-advance -->
+        <div class="mb-3">
+            <label for="playlistAutoAdvance" class="form-label">Auto-advance to next tab in playlist</label>
+            <select id="playlistAutoAdvance" class="form-select" v-model="setting.playlistAutoAdvance">
                 <option :value="false">No</option>
                 <option :value="true">Yes</option>
             </select>

--- a/frontend/src/pages/Tab.vue
+++ b/frontend/src/pages/Tab.vue
@@ -1,5 +1,5 @@
 <script>
-import { ActionBuffer, baseURL, checkFetch, connectSocketIO, convertAlphaTexSyncPoint, generalError, getInstrumentName, getSetting, releaseWakeLock, requestWakeLock } from "../app.js";
+import { ActionBuffer, baseURL, checkFetch, connectSocketIO, convertAlphaTexSyncPoint, generalError, getInstrumentName, getShortInstrumentName, getSetting, isGuitarOrBass, releaseWakeLock, requestWakeLock } from "../app.js";
 import { defineComponent } from "vue";
 import { BDropdown, BDropdownDivider, BDropdownItem } from "bootstrap-vue-next";
 import { notify } from "@kyvg/vue3-notification";
@@ -51,7 +51,7 @@ export default defineComponent({
             isLooping: false,
             speed: 100,
             ready: false,
-            selectedTrack: 0,
+            selectedTracks: [0],
             soloTrackID: -1,
             muteTrackList: {},
             currentAudio: "synth",
@@ -61,6 +61,11 @@ export default defineComponent({
             scrollMode: ScrollMode.Continuous,
             keySignature: "",
             playbackRange: null,
+            playlistId: null,
+            playlistData: null,
+            playlistTabs: [],
+            autoAdvanceTimer: null,
+            autoAdvanceCountdown: 0,
 
             keyEvents: (e) => {
                 // Do not handle these tagName, because the only input is sync point, it is weird when play space to test the sync point
@@ -320,12 +325,30 @@ export default defineComponent({
         const urlParams = new URLSearchParams(window.location.search);
 
         try {
-            // Override trackID if provided in URL
+            // Override trackIDs if provided in URL (supports comma-separated: ?track=0,2,3)
             const trackParam = urlParams.get("track");
             if (trackParam) {
-                const id = parseInt(trackParam);
-                if (!isNaN(id)) {
-                    this.setConfig("trackID", id);
+                const ids = trackParam.split(",").map((s) => parseInt(s.trim())).filter((n) => !isNaN(n));
+                if (ids.length > 0) {
+                    this.setConfig("trackIDs", ids.slice(0, 4));
+                }
+            }
+
+            // Load playlist context if provided in URL
+            const playlistParam = urlParams.get("playlist");
+            if (playlistParam) {
+                this.playlistId = playlistParam;
+                try {
+                    const plRes = await fetch(baseURL + `/api/playlist/${playlistParam}`, {
+                        credentials: "include",
+                    });
+                    const plData = await plRes.json();
+                    if (plData.ok) {
+                        this.playlistData = plData.playlist;
+                        this.playlistTabs = plData.tabs;
+                    }
+                } catch {
+                    // Playlist loading failed, continue without it
                 }
             }
 
@@ -335,10 +358,15 @@ export default defineComponent({
                 this.setConfig("audio", audioParam);
             }
 
-            const trackID = this.getConfig("trackID", 0);
+            // Load stored trackIDs with backward compat (old "trackID" was a single number)
+            let trackIDs = this.getConfig("trackIDs", null);
+            if (!trackIDs) {
+                const legacyID = this.getConfig("trackID", 0);
+                trackIDs = [legacyID];
+            }
 
             // Load the AlphaTab
-            await this.load(trackID);
+            await this.load(trackIDs);
 
             window.addEventListener("keydown", this.keyEvents);
 
@@ -381,6 +409,7 @@ export default defineComponent({
     },
     beforeUnmount() {
         console.log("Before unmount");
+        this.cancelAutoAdvance();
         this.destroyContainer();
         window.removeEventListener("keydown", this.keyEvents);
 
@@ -392,7 +421,12 @@ export default defineComponent({
         this.socket.disconnect();
     },
     methods: {
-        async load(trackID) {
+        async load(trackIDs) {
+            // Normalize: accept a single number for backward compat
+            if (typeof trackIDs === "number") {
+                trackIDs = [trackIDs];
+            }
+
             if (this.api) {
                 this.destroyContainer();
             }
@@ -421,10 +455,10 @@ export default defineComponent({
 
             const tempToken = await this.getTempToken();
 
-            // Requested trackID may be invalid, so we need to get the actual trackID used
-            trackID = await this.initContainer(tempToken, trackID);
+            // Requested trackIDs may be invalid, so we get the actual validated list back
+            trackIDs = await this.initContainer(tempToken, trackIDs);
 
-            this.setConfig("trackID", trackID);
+            this.setConfig("trackIDs", trackIDs);
         },
 
         countIn() {
@@ -489,8 +523,8 @@ export default defineComponent({
                 return;
             }
 
-            // Find the first bar containing notes in the current track
-            const track = this.api.score.tracks[this.selectedTrack];
+            // Find the first bar containing notes in the primary track
+            const track = this.api.score.tracks[this.selectedTracks[0]];
 
             let targetBar = null;
 
@@ -551,10 +585,15 @@ export default defineComponent({
 
         /**
          * @param tempToken
-         * @param trackID
-         * @returns {Promise<number>} The actual trackID used
+         * @param trackIDs - array of track indices to display
+         * @returns {Promise<number[]>} The actual trackIDs used
          */
-        initContainer(tempToken, trackID) {
+        initContainer(tempToken, trackIDs) {
+            // Normalize input
+            if (typeof trackIDs === "number") {
+                trackIDs = [trackIDs];
+            }
+
             return new Promise((resolve, reject) => {
                 if (this.api) {
                     this.destroyContainer();
@@ -653,19 +692,32 @@ export default defineComponent({
 
                     this.applyColors(score);
 
-                    // Track
-                    if (trackID < 0 || trackID >= score.tracks.length) {
-                        trackID = 0;
+                    // Fix track names: override file metadata with correct instrument names
+                    for (const track of score.tracks) {
+                        track.name = getInstrumentName(track.playbackInfo.program);
+                        track.shortName = getShortInstrumentName(track.playbackInfo.program);
                     }
-                    this.api.renderTracks([this.api.score.tracks[trackID]]);
+
+                    // Validate and clamp trackIDs
+                    trackIDs = trackIDs
+                        .filter((id) => id >= 0 && id < score.tracks.length)
+                        .slice(0, 4);
+                    if (trackIDs.length === 0) {
+                        trackIDs = [0];
+                    }
+
+                    // Render selected tracks
+                    const trackObjects = trackIDs.map((id) => this.api.score.tracks[id]);
+                    this.api.renderTracks(trackObjects);
 
                     // Always show tempo automation on the master bar
                     if (api.score.masterBars.length > 0 && api.score.masterBars[0].tempoAutomations.length > 0) {
                         api.score.masterBars[0].tempoAutomations[0].isVisible = true;
                     }
 
-                    // Get key signature
-                    const firstBar = this.api.score.tracks[trackID].staves[0].bars[0];
+                    // Get key signature from primary (first) track
+                    const primaryTrackID = trackIDs[0];
+                    const firstBar = this.api.score.tracks[primaryTrackID].staves[0].bars[0];
                     this.keySignature = getKeySignature(firstBar);
 
                     // Set Audio source
@@ -703,26 +755,43 @@ export default defineComponent({
                         });
                     });
 
-                    this.selectedTrack = trackID;
+                    this.selectedTracks = trackIDs;
 
-                    // Force score+tab if the current track program = 0 (probably drums)
+                    // Force score+tab if the primary track is drums
                     if (this.isDrum()) {
                         this.api.settings.display.staveProfile = StaveProfile.ScoreTab;
                         this.api.updateSettings();
                     } else {
-                        // This will break drum score
+                        // Check if any rendered track has tablature data
+                        const renderedTracks = trackIDs.map((id) => score.tracks[id]);
+                        const anyHasTab = renderedTracks.some((t) =>
+                            t.staves.some((s) => s.stringTuning && s.stringTuning.tunings && s.stringTuning.tunings.length > 0)
+                        );
+
+                        if (!anyHasTab) {
+                            // No tracks have tab data (e.g. MusicXML) — force score globally
+                            this.api.settings.display.staveProfile = StaveProfile.Score;
+                            this.api.updateSettings();
+                        }
+
+                        // Apply per-staff overrides for all modes including auto
                         this.overrideHiddenStaves(score);
                     }
 
                     this.enableBackingTrack = this.hasBackingTrack();
 
                     this.ready = true;
-                    resolve(trackID);
+                    resolve(trackIDs);
                 });
 
                 this.api.playerFinished.on(() => {
                     if (!this.isLooping) {
                         this.playing = false;
+
+                        // Auto-advance to next tab in playlist
+                        if (this.playlistData) {
+                            this.startAutoAdvance();
+                        }
                     }
                 });
             });
@@ -824,17 +893,31 @@ export default defineComponent({
         },
 
         /**
-         * Override hidden staves based on Style settings to fix Guitar Pro hidden tabs.
-         * ⚠️ This will break drum score
-         * - Style "tab": showTablature = true, showStandardNotation = false
-         * - Style "score": showTablature = false, showStandardNotation = true
-         * - Style "score-tab": both = true
+         * Override hidden staves based on Style settings and track capabilities.
+         * Only modifies tracks that have string tuning data (guitar/bass from GP files).
+         * Tracks without tab data (MusicXML wind instruments etc.) are left untouched
+         * so AlphaTab's parser defaults handle them correctly.
+         * ⚠️ Drums are handled separately before this is called.
          */
         overrideHiddenStaves(score) {
             for (const track of score.tracks) {
                 for (const staff of track.staves) {
-                    // Override visibility flags based on user's Style setting
-                    if (this.setting.scoreStyle === "tab" || this.setting.scoreStyle === "horizontal-tab") {
+                    const hasTab = staff.stringTuning && staff.stringTuning.tunings && staff.stringTuning.tunings.length > 0;
+
+                    if (this.setting.scoreStyle === "auto") {
+                        // Auto: show tab for stringed instruments, score for everything else
+                        if (hasTab) {
+                            staff.showTablature = true;
+                            staff.showStandardNotation = false;
+                        } else {
+                            staff.showTablature = false;
+                            staff.showStandardNotation = true;
+                        }
+                    } else if (!hasTab) {
+                        // Non-tab tracks always get score regardless of setting
+                        staff.showTablature = false;
+                        staff.showStandardNotation = true;
+                    } else if (this.setting.scoreStyle === "tab" || this.setting.scoreStyle === "horizontal-tab") {
                         staff.showTablature = true;
                         staff.showStandardNotation = false;
                     } else if (this.setting.scoreStyle === "score") {
@@ -1253,38 +1336,93 @@ export default defineComponent({
         },
 
         /**
-         * Check if the current track is a drum track (program 0).
-         * this.selectedTrack must be set before calling this function.
+         * Check if the primary (first selected) track is a drum track (program 0).
+         * this.selectedTracks must be set before calling this function.
          * @returns {boolean}
          */
         isDrum() {
             if (!this.api || !this.api.score || !this.api.score.tracks) {
                 return false;
             }
-            const track = this.api.score.tracks[this.selectedTrack];
+            const track = this.api.score.tracks[this.selectedTracks[0]];
             return track.playbackInfo.program === 0;
         },
 
         /**
-         * Change the displayed track.
+         * Toggle a track's visibility in the multi-track display.
+         * If toggling ON and already at max (4), does nothing.
+         * Cannot toggle OFF the last remaining track.
          * @param trackID
          * @returns {Promise<void>}
          */
-        async changeTrack(trackID) {
-            const fromDrum = this.isDrum();
-            this.selectedTrack = trackID;
-            const isDrum = this.isDrum();
+        async toggleTrackDisplay(trackID) {
+            const idx = this.selectedTracks.indexOf(trackID);
 
-            // If switching from/to drum track, need to re-render the whole score
-            // Due to the bug that Drum is not able to render in Tab View
-            if (fromDrum || isDrum) {
-                await this.load(trackID);
+            if (idx >= 0) {
+                // Track is currently shown — remove it (unless it's the last one)
+                if (this.selectedTracks.length <= 1) {
+                    return;
+                }
+                this.selectedTracks.splice(idx, 1);
             } else {
-                this.api.renderTracks([this.api.score.tracks[trackID]]);
-                this.setConfig("trackID", trackID);
+                // Track is not shown — add it (if under max)
+                if (this.selectedTracks.length >= 4) {
+                    return;
+                }
+                this.selectedTracks.push(trackID);
             }
 
-            this.closeAllList();
+            // Check if any selected track is a drum — requires full reload
+            const hasDrum = this.selectedTracks.some((id) => {
+                const t = this.api.score.tracks[id];
+                return t && t.playbackInfo.program === 0;
+            });
+
+            if (hasDrum) {
+                await this.load(this.selectedTracks);
+            } else {
+                const trackObjects = this.selectedTracks.map((id) => this.api.score.tracks[id]);
+                this.api.renderTracks(trackObjects);
+                this.setConfig("trackIDs", this.selectedTracks);
+            }
+        },
+
+        /**
+         * Set a track as the primary (first) track for cursor/navigation.
+         * If the track is not currently displayed, it will be added.
+         * @param trackID
+         * @returns {Promise<void>}
+         */
+        async setPrimaryTrack(trackID) {
+            const idx = this.selectedTracks.indexOf(trackID);
+
+            if (idx === 0) {
+                // Already primary, do nothing
+                return;
+            }
+
+            if (idx > 0) {
+                // Move to front
+                this.selectedTracks.splice(idx, 1);
+            } else if (this.selectedTracks.length >= 4) {
+                // At max, replace last
+                this.selectedTracks.pop();
+            }
+            this.selectedTracks.unshift(trackID);
+
+            // Check drum status
+            const hasDrum = this.selectedTracks.some((id) => {
+                const t = this.api.score.tracks[id];
+                return t && t.playbackInfo.program === 0;
+            });
+
+            if (hasDrum) {
+                await this.load(this.selectedTracks);
+            } else {
+                const trackObjects = this.selectedTracks.map((id) => this.api.score.tracks[id]);
+                this.api.renderTracks(trackObjects);
+                this.setConfig("trackIDs", this.selectedTracks);
+            }
         },
 
         showList(type) {
@@ -1358,6 +1496,51 @@ export default defineComponent({
 
         hasBackingTrack() {
             return !!this.api.score.backingTrack;
+        },
+
+        // Playlist navigation
+        playlistCurrentIndex() {
+            if (!this.playlistData) return -1;
+            return this.playlistData.tabIds.indexOf(this.tabID);
+        },
+
+        playlistPrevTab() {
+            const idx = this.playlistCurrentIndex();
+            if (idx <= 0) return null;
+            return this.playlistData.tabIds[idx - 1];
+        },
+
+        playlistNextTab() {
+            const idx = this.playlistCurrentIndex();
+            if (idx < 0 || idx >= this.playlistData.tabIds.length - 1) return null;
+            return this.playlistData.tabIds[idx + 1];
+        },
+
+        goToPlaylistTab(tabId) {
+            this.cancelAutoAdvance();
+            this.$router.push(`/tab/${tabId}?playlist=${this.playlistId}`);
+        },
+
+        startAutoAdvance() {
+            const nextId = this.playlistNextTab();
+            if (!nextId || !this.setting.playlistAutoAdvance) return;
+
+            this.autoAdvanceCountdown = 3;
+            this.autoAdvanceTimer = setInterval(() => {
+                this.autoAdvanceCountdown--;
+                if (this.autoAdvanceCountdown <= 0) {
+                    this.cancelAutoAdvance();
+                    this.goToPlaylistTab(nextId);
+                }
+            }, 1000);
+        },
+
+        cancelAutoAdvance() {
+            if (this.autoAdvanceTimer) {
+                clearInterval(this.autoAdvanceTimer);
+                this.autoAdvanceTimer = null;
+                this.autoAdvanceCountdown = 0;
+            }
         },
 
         setConfig(key, value) {
@@ -1454,6 +1637,12 @@ export default defineComponent({
 
 <template>
     <div class="main" :class='{ "light": this.setting.scoreColor === "light" }'>
+        <div class="playlist-badge text-center mb-1" v-if="playlistData">
+            <span class="badge bg-info">
+                <font-awesome-icon :icon='["fas", "list"]' />
+                {{ playlistData.name }}
+            </span>
+        </div>
         <h1>{{ tab.title }}</h1>
         <h2>{{ tab.artist }}</h2>
         <div class="key-signature badge bg-secondary" v-if="keySignature && setting.showKeySignature">
@@ -1468,7 +1657,10 @@ export default defineComponent({
             <div class="scroll">
                 <div class="track-selector selector" ref="trackSelector">
                     <div class="button" @click='showList("track")'>
-                        <span v-if="tracks.length > 0">{{ tracks[selectedTrack].name }}</span>
+                        <span v-if="tracks.length > 0">
+                            {{ tracks[selectedTracks[0]].name }}
+                            <span v-if="selectedTracks.length > 1" class="track-count-badge">+{{ selectedTracks.length - 1 }}</span>
+                        </span>
                         <span v-else>Loading...</span>
                     </div>
                 </div>
@@ -1511,6 +1703,24 @@ export default defineComponent({
                     Speed: <input type="number" class="form-control" min="0" max="1000" step="1" v-model="speed" /> (%)
                 </div>
 
+                <!-- Playlist nav -->
+                <template v-if="playlistData">
+                    <button class="btn btn-secondary" @click="goToPlaylistTab(playlistPrevTab())" :disabled="!playlistPrevTab()">
+                        <font-awesome-icon :icon='["fas", "backward-step"]' />
+                        Prev
+                    </button>
+                    <button class="btn btn-secondary" @click="goToPlaylistTab(playlistNextTab())" :disabled="!playlistNextTab()">
+                        Next
+                        <font-awesome-icon :icon='["fas", "forward-step"]' />
+                    </button>
+                </template>
+
+                <!-- Auto-advance countdown -->
+                <div class="auto-advance-notice" v-if="autoAdvanceCountdown > 0">
+                    Next in {{ autoAdvanceCountdown }}s
+                    <button class="btn btn-sm btn-outline-light ms-1" @click="cancelAutoAdvance">Cancel</button>
+                </div>
+
                 <div class="btn-edit" v-if="isLoggedIn">
                     <button class="btn btn-secondary" @click="edit()">
                         Edit
@@ -1523,8 +1733,12 @@ export default defineComponent({
                     <font-awesome-icon :icon='["fas", "xmark"]' class="me-2 close" @click="showTrackList = false" />
                 </div>
 
-                <div class="track item" v-for="track in tracks" :key="track.id" :class="{ active: selectedTrack === track.id }">
-                    <div class="name" @click="changeTrack(track.id)">{{ track.name }}</div>
+                <div class="track item" v-for="track in tracks" :key="track.id" :class="{ active: selectedTracks.includes(track.id), primary: selectedTracks[0] === track.id }">
+                    <div class="name" @click="setPrimaryTrack(track.id)">{{ track.name }}</div>
+                    <div class="list-button show-toggle" @click="toggleTrackDisplay(track.id)" :class="{ active: selectedTracks.includes(track.id) }">
+                        <span v-if="selectedTracks.includes(track.id)">Shown</span>
+                        <span v-else>Show</span>
+                    </div>
                     <div class="list-button solo" @click="toggleSolo(track.id)" :class="{ active: soloTrackID === track.id }">Solo</div>
                     <div class="list-button mute" @click="toggleMute(track.id)" :class="{ active: muteTrackList[track.id] }">Mute</div>
                     <div class="list-button select-percentage">
@@ -1783,13 +1997,43 @@ $padding: 20px;
     }
 }
 
+.auto-advance-notice {
+    display: flex;
+    align-items: center;
+    white-space: nowrap;
+    color: #ffc107;
+    font-weight: bold;
+    padding: 0 8px;
+}
+
+.track-count-badge {
+    display: inline-block;
+    background-color: $primary;
+    color: white;
+    border-radius: 10px;
+    padding: 1px 7px;
+    font-size: 12px;
+    margin-left: 4px;
+    vertical-align: middle;
+}
+
 .track-list {
     .track {
+        &.primary {
+            border-left: 3px solid $primary;
+        }
+
         .list-button {
             background-color: lighten($color, 10%);
             border-right: 1px solid darken($color, 5%);
             padding: $padding;
             height: 100%;
+            min-height: 44px;
+            min-width: 44px;
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            user-select: none;
 
             &:hover {
                 background-color: lighten($primary, 5%);
@@ -1798,6 +2042,11 @@ $padding: 20px;
             &.active {
                 background-color: lighten($primary, 8%);
             }
+        }
+
+        .show-toggle {
+            font-weight: bold;
+            min-width: 70px;
         }
     }
 }

--- a/frontend/src/pages/TabConfig.vue
+++ b/frontend/src/pages/TabConfig.vue
@@ -15,6 +15,7 @@ export default defineComponent({
         return {
             tabID: -1,
             tab: {},
+            tagsInput: "",
             page: "",
             youtubeURL: "",
             youtubeList: [],
@@ -52,6 +53,7 @@ export default defineComponent({
                 await checkFetch(res);
                 const data = await res.json();
                 this.tab = data.tab;
+                this.tagsInput = (data.tab.tags || []).join(", ");
                 this.youtubeList = data.youtubeList;
                 this.audioList = data.audioList;
                 this.filePath = data.filePath;
@@ -63,6 +65,9 @@ export default defineComponent({
 
         async submitInfo() {
             try {
+                // Parse tags from comma-separated input
+                this.tab.tags = this.tagsInput.split(",").map((t) => t.trim()).filter((t) => t.length > 0);
+
                 const tabID = this.$route.params.id;
                 const res = await fetch(baseURL + `/api/tab/${tabID}`, {
                     method: "POST",
@@ -74,6 +79,7 @@ export default defineComponent({
                         title: this.tab.title,
                         artist: this.tab.artist,
                         public: this.tab.public,
+                        tags: this.tab.tags || [],
                     }),
                 });
 
@@ -409,6 +415,13 @@ export default defineComponent({
                         <option :value="false">Private</option>
                         <option :value="true">Public</option>
                     </select>
+                </div>
+
+                <!-- Tags -->
+                <div class="mb-3">
+                    <label for="tabTags" class="form-label">Tags</label>
+                    <input type="text" class="form-control" id="tabTags" v-model="tagsInput" placeholder="e.g. rock, jazz, practice">
+                    <div class="form-text">Comma-separated tags for organizing your tabs</div>
                 </div>
 
                 <!-- Save -->

--- a/frontend/src/router.ts
+++ b/frontend/src/router.ts
@@ -10,6 +10,7 @@ import Settings from "./pages/Settings.vue";
 import TabNew from "./pages/TabNew.vue";
 
 const Tab = () => import("./pages/Tab.vue");
+const Playlist = () => import("./pages/Playlist.vue");
 
 const routes: RouteRecordRaw[] = [
     {
@@ -47,6 +48,11 @@ const routes: RouteRecordRaw[] = [
                         path: "/tab/:id",
                         component: Tab,
                         meta: { hideFooter: true },
+                    },
+                    {
+                        name: "playlist",
+                        path: "/playlist/:id",
+                        component: Playlist,
                     },
                     {
                         name: "settings",

--- a/frontend/src/zod.ts
+++ b/frontend/src/zod.ts
@@ -2,7 +2,7 @@ import * as z from "zod";
 import { ScrollMode } from "@coderline/alphatab";
 
 export const SettingSchema = z.object({
-    scoreStyle: z.enum(["tab", "score-tab", "score", "auto", "horizontal-tab"]).default("tab"),
+    scoreStyle: z.enum(["auto", "tab", "score-tab", "score", "horizontal-tab"]).default("auto"),
     scoreColor: z.enum(["light", "dark"]).default("dark"),
     noteColor: z.enum(["rocksmith", "louis-bass-v", "none"]).default("rocksmith"),
     cursor: z.enum(["animated", "instant", "bar", "invisible"]).default(
@@ -10,8 +10,10 @@ export const SettingSchema = z.object({
     ),
     scrollMode: z.enum(ScrollMode).default(ScrollMode.Continuous),
     groupByArtist: z.boolean().default(false),
+    tabSortBy: z.enum(["title", "artist", "dateNewest", "dateOldest"]).default("dateNewest"),
     showKeySignature: z.boolean().default(false),
     scale: z.number().min(0.1).default(1),
     toolbarAutoHide: z.boolean().default(false),
+    playlistAutoAdvance: z.boolean().default(false),
 });
 export type Setting = z.infer<typeof SettingSchema>;


### PR DESCRIPTION
## Summary

- **Multi-track display**: show up to 4 tracks simultaneously with per-track Show/Shown toggles and primary track selection; `?track=` URL param now accepts comma-separated IDs
- **Auto style mode** (new default): auto-detects per-track whether to show tab or standard notation based on string tuning data; fixes MXL/MusicXML files rendering correctly
- **MusicXML (.mxl)** format now supported for upload
- **Short instrument abbreviations** on stave margins (Gtr, Bass, Flute…) replacing raw file metadata names
- **Playlists**: create/manage playlists, drag-to-reorder, prev/next player navigation, optional auto-advance to next tab; new `/playlist/:id` page and 7 API endpoints (Deno KV backed)
- **File manager**: sort by date/title/artist, tag tabs, filter by tag, bulk select/delete/add-to-playlist

## Test plan

- [ ] Upload a multi-instrument GP file; toggle 2–3 tracks ON and verify staves render stacked
- [ ] Verify cursor follows primary track during playback
- [ ] Test `?track=0,2` URL loads both tracks
- [ ] Upload an MXL file; verify staves render in auto mode (standard notation)
- [ ] Test style setting: auto, tab, score, score-tab all behave correctly
- [ ] Sort tab list by each option; verify order is correct
- [ ] Add tags to a tab via TabConfig; filter by tag on home page
- [ ] Bulk select tabs; delete and add-to-playlist work
- [ ] Create a playlist, add tabs, drag to reorder, save
- [ ] Open a tab from playlist context; prev/next buttons appear
- [ ] Enable auto-advance; verify navigation triggers after playback ends
- [ ] Test on mobile/iPad (touch interactions, toggle switches)

🤖 Generated with [Claude Code](https://claude.ai/claude-code)